### PR TITLE
tinerator: small fix in basic_example regarding layering

### DIFF
--- a/tinerator/examples/basic_example.py
+++ b/tinerator/examples/basic_example.py
@@ -16,8 +16,8 @@ my_dem.generateBoundary(10.)
 my_dem.plotBoundary()
 
 # Define the layers and corresponding material ids
-layers = (0.1*50.,0.3*50.,0.6*50.,8.0*50.,21.0*50.)
-matids = (1,2,3,4,5)
+layers = (0.0*50.0, 0.1*50.,0.3*50.,0.6*50.,8.0*50.,21.0*50.)
+matids = (1,2,3,4,5,6)
 
 my_dem.generateStackedTIN("test_extruded_mesh.inp",layers,matids=matids,plot=True)
 


### PR DESCRIPTION
fix a small bug in the basic example.

Using the basic example as is creates 4 layers instead of the expected 5.
The reason might be as follows:
If the method `generateStackedTIN` is given a list of layer z-coordinate offsets, it skips the top layer. This method calls LaGriT's `stack/layers` method which takes surface z-elevations as input and creates layers between two surfaces. This means, that in `tinerator`, the first layer entry should always be '0.0'. This is incorrect in the `basic_example.py`, and the top layer is missing. I guess it is also unexpected behavior, and might be fixed in the future.