### PR TITLE
tinerator: fix stacking layers

### DIFF
--- a/tinerator/examples/basic_example.py
+++ b/tinerator/examples/basic_example.py
@@ -15,8 +15,8 @@ my_dem.generateBoundary(10.)
 my_dem.plotBoundary()
 
 # Define the layers and corresponding material ids
-layers = (0.1*50.,0.3*50.,0.6*50.,8.0*50.,21.0*50.)
-matids = (1,2,3,4,5)
+layers = [0.1*50.,0.3*50.,0.6*50.,8.0*50.,21.0*50.]
+matids = [1,2,3,4,5]
 
 my_dem.generateStackedTIN("test_extruded_mesh.inp",layers,matids=matids,plot=False)
 

--- a/tinerator/tinerator/generate_triplane.py
+++ b/tinerator/tinerator/generate_triplane.py
@@ -175,6 +175,11 @@ def stackLayers(lg:pylagrit.PyLaGriT,infile:str,outfile:str,layers:list,
     :type matids: list
     '''
 
+    if layers[0] != 0.:
+        layers = [0.0] + layers
+        matids = [0] + matids
+        assert len(layers) == len(matids)
+
     stack_files = ['layer%d.inp' % (len(layers)-i) for i in range(len(layers))]
     if nlayers is None:
         nlayers=['']*(len(stack_files)-1)


### PR DESCRIPTION
In the previous version, providing `n` z-coordinates for the `layers`
variable in `generateStackedTIN` created `n-1` layers, because the
provided values are used as coordinates of the layer interfaces. In
our use cases, this is unexpected behavior. In order to fix this, we
now added a check in the `stackLayers` method in `generate_triplane`
to test if the first entry of `layers` is `0.0`. If not, an additional
value of `0.0` is added to the list, ensuring that stacking starts from
the provided top surface mesh.

The implementation is tested with `basic_example`, and creates the
expected 5 layers.

This addresses the closed pull request lanl/LaGriT#115