### PR TITLE
add argument to set the exponent for delineation

### DIFF
--- a/tinerator/dem_class.py
+++ b/tinerator/dem_class.py
@@ -210,6 +210,7 @@ class DEM():
     def watershed_delineation(self,
                               threshold:float,
                               method:str='D8',
+                              exponent:float=None,
                               interactive:bool=False):
         '''
         Performs watershed delineation on a DEM and returns a set of points
@@ -249,7 +250,8 @@ class DEM():
                 cfg.log.warn('Cannot init Jupyter notebook functionality')
 
         self.accumulation_matrix = delin.watershedDelineation(self.dem,
-                                                              method=method)
+                                                              method=method,
+                                                              exponent=exponent)
 
         if threshold is None:
             _thresh = np.unique(accumulation)


### PR DESCRIPTION
Although the argument `exponent` is defined in
`watershed_delineation`-method `watershedDelineation`, the calling
method in `dem_class` (`watershed_delineation`) did not have this
argument, so the user could not set an exponent at the top level. This
caused delineation methods such as `Holmgren` and `Freeman` to fail.

This commit gives an `exponent` argument to `dem_class`-method
`watershed_delineation` and sets this exponent as input to
`watershed_delineation`-method `watershedDelineation`.

The interactive part still does not get `exponent` as an argument.

fixes #149