### PR TITLE
add a warning if exponent is used for invalid methods

### DIFF
--- a/tinerator/dem_class.py
+++ b/tinerator/dem_class.py
@@ -249,6 +249,10 @@ class DEM():
             else:
                 cfg.log.warn('Cannot init Jupyter notebook functionality')
 
+        if (exponent is not None) and (method not in ['Holmgren', 'Freeman']):
+            cfg.log.warn("Ignoring exponent: exponent is only valid " + \
+                         "for Holmgren/Freeman methods")
+        
         self.accumulation_matrix = delin.watershedDelineation(self.dem,
                                                               method=method,
                                                               exponent=exponent)


### PR DESCRIPTION
If a non-nil value for `exponent` is used in the `watershed_delineation`
method in `dem_class`, a warning is issued to the user if the method is
neither `Holmgren` nor `Freeman`. `exponent` is then ignored in the
following calculations.